### PR TITLE
Provide more functionalities

### DIFF
--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -92,7 +92,7 @@ module AndroidCIHelper
         adb_cmd "start-server"
     end
 
-    # For most of the junit-tests, we don't need skip to pass the tests.
+    # For most of the junit-tests, we don't need skin to pass the tests.
     # However, without skin, the functional tests cannot properly locate the UI
     # element and the tests will fail.
     def self.start_and_wait_for_ready(emulator_name, no_skin:true)

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -52,16 +52,6 @@ module AndroidCIHelper
 
         connected_emulators = list_connected_emulators
         ports = []
-        # connected_emulators.each { |emu|
-        #     ports << emu.split("-").last if emu.include? "emulator"
-        #     # skip if it does not contain emulator prefix (i.e., it's a real
-        #     # device)
-        # }
-        #
-        # ports.each do |port|
-        #     avd_name = get_emulator_name(port)
-        #     devices << avd_name unless avd_name.empty?
-        # end
         devices = connected_emulators.map { |emu|
             port = emu.split("-").last
             avd_name = get_emulator_name(port)

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -27,13 +27,9 @@ module AndroidCIHelper
         list_avd = `#{ANDROID_CMD} list avd`
         names = list_avd.split("\n").grep(/Name:/).map { |name| name.strip.split[1] }
         if version
-            targets = list_avd.split("\n").grep(/Target:/).map { |target| target.strip.split(":")[1] }
-            abis = list_avd.split("\n").grep(/Tag\/ABI:/).map { |tagAbi| tagAbi.strip.split(":")[1] }
-            tmp = []
-            0.upto(targets.length-1) do |i|
-                tmp << names[i] if (targets[i].include?(version)) && (abi.nil? || abis[i].include?(abi))
+            names.select!.with_index do |name, index|
+                targets[index].include?(version) && (abi.nil? || abis[index].include?(abi))
             end
-            names = tmp
         end
         names
     end

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -48,12 +48,10 @@ module AndroidCIHelper
 
     # list device actual name such as android-avd-21
     def self.list_running_emulators
-        devices = list_connected_emulators.map { |emu|
+        list_connected_emulators.map { |emu|
             port = emu.split("-").last
             avd_name = get_emulator_name(port)
         }.compact
-
-        devices
     end
 
     def self.get_emulator_name(port)

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -3,7 +3,7 @@ require "android_ci_helper/version"
 module AndroidCIHelper
 
     ANDROID_HOME = ENV['ANDROID_HOME'] || raise("Error: must set $ANDROID_HOME environment variable")
-    
+
     ADB_CMD = File.join(ANDROID_HOME, 'platform-tools', 'adb')
     EMULATOR_CMD = File.join(ANDROID_HOME, 'tools', 'emulator')
     ANDROID_CMD = File.join(ANDROID_HOME, 'tools', 'android')
@@ -22,13 +22,31 @@ module AndroidCIHelper
         shell_out "#{ADB_CMD} #{cmd}"
     end
 
-    def self.list_installed_emulators
-        # collect array like ["Name: <emu-name> ", "Name: <another-emu-name>"]
-        name_output = `#{ANDROID_CMD} list avd`.split("\n").grep(/Name:/)
-        names = name_output.map { |name| name.strip.split.last }
-        return names
+    def self.list_installed_emulators(version: nil, abi: "armeabi-v7a")
+        list_avd = `#{ANDROID_CMD} list avd`
+        names = []
+        list_avd.split("\n").grep(/Name:/).each { |name|
+            names << name.strip().split()[1]
+        }
+        targets = []
+        list_avd.split("\n").grep(/Target:/).each { |target|
+            targets << target.strip().split(":")[1]
+        }
+        abis = []
+        list_avd.split("\n").grep(/Tag\/ABI:/).each { |tagAbi|
+            abis << tagAbi.strip().split(":")[1]
+        }
+        if version
+            tmp = []
+            for i in 0..(targets.length-1)
+                tmp << names[i] if (targets[i].include?(version)) && (abi.nil? || abis[i].include?(abi))
+            end
+            names = tmp
+        end
+        names
     end
 
+    # list device connected name such as emulator-5554
     def self.list_connected_emulators
         output = `#{ADB_CMD} devices`.split("\n")
         return [] unless output.count > 1
@@ -36,6 +54,32 @@ module AndroidCIHelper
         # first line is "List of devices attached"
         emulators = output.drop(1).map { |line| line.split("\t").first }
         return emulators
+    end
+
+    # list device actual name such as android-avd-21
+    def self.list_running_emulators
+        devices = []
+        # both linux and darwin provide command ps but they behavior differently
+        # by default. On linux, it only shows processes under the same terminal
+        # while on darwin, it shows processes under the same user id with the
+        # caller. On linux, we use param: aux to show all process belonging to
+        # the caller.
+        ps_cmd = "ps -aux"
+        host_os = RbConfig::CONFIG['host_os']
+        ps_cmd = "ps" if host_os.include?("darwin") || host_os.include?("mac os")
+        ps = `#{ps_cmd}`
+
+        ps.split("\n").grep(/emulator/).each do |t|
+            avd_token_found = false
+            t.split(" ").each do |t2|
+                if avd_token_found
+                    devices << t2
+                    break
+                end
+                avd_token_found = true if t2=="-avd"
+            end
+        end
+        return devices
     end
 
     def self.adb_prop_eq?(prop, expected)
@@ -49,9 +93,9 @@ module AndroidCIHelper
         adb_prop_eq?("dev.bootcomplete",       "1")       or return false
         adb_prop_eq?("sys.boot_completed",     "1")       or return false
 
-        (adb_prop_eq?("service.bootanim.exit", "1") || 
+        (adb_prop_eq?("service.bootanim.exit", "1") ||
             adb_prop_eq?("init.svc.bootanim", "stopped")) or return false
-        
+
         return true
     end
 
@@ -64,11 +108,16 @@ module AndroidCIHelper
         adb_cmd "start-server"
     end
 
-    def self.start_and_wait_for_ready(emulator_name)
+    # For most of the junit-tests, we don't need skip to pass the tests.
+    # However, without skin, the functional tests cannot properly locate the UI
+    # element and the tests will fail.
+    def self.start_and_wait_for_ready(emulator_name, no_skin:true)
         puts "--- starting emulator #{emulator_name}..."
-        
+
         $emulator_pid = fork {
-            puts `#{EMULATOR_CMD} -avd #{emulator_name} -no-skin -no-audio -no-window -wipe-data`
+            additional_params = ''
+            additional_params += "-no-skin" if no_skin
+            puts `#{EMULATOR_CMD} -avd #{emulator_name}-no-audio -no-window -wipe-data #{additional_params}`
         }
 
         puts "--- checking emulator pid: #{$emulator_pid}"
@@ -84,7 +133,8 @@ module AndroidCIHelper
         puts "--- emulator process is alive"
 
         # wait for ready
-        1.upto(20) do |attempt|
+        # change to 30 because on my dev machine it might take up to 27 tries before success
+        1.upto(30) do |attempt|
             puts "--- attempt ##{attempt}"
             break if emulator_ready?
             puts "--- waiting 10 seconds before next attempt"
@@ -95,7 +145,7 @@ module AndroidCIHelper
             puts "******** error starting #{emulator_name} - timed out waiting for ready ********"
             return false
         end
-        
+
         puts "--- emulator #{emulator_name} is ready"
         return true
     end

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -79,7 +79,7 @@ module AndroidCIHelper
                 avd_token_found = true if t2=="-avd"
             end
         end
-        return devices
+        devices
     end
 
     def self.adb_prop_eq?(prop, expected)
@@ -117,7 +117,7 @@ module AndroidCIHelper
         $emulator_pid = fork {
             additional_params = ''
             additional_params += "-no-skin" if no_skin
-            puts `#{EMULATOR_CMD} -avd #{emulator_name}-no-audio -no-window -wipe-data #{additional_params}`
+            puts `#{EMULATOR_CMD} -avd #{emulator_name} -no-audio -no-window -wipe-data #{additional_params}`
         }
 
         puts "--- checking emulator pid: #{$emulator_pid}"

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -48,11 +48,7 @@ module AndroidCIHelper
 
     # list device actual name such as android-avd-21
     def self.list_running_emulators
-        devices = []
-
-        connected_emulators = list_connected_emulators
-        ports = []
-        devices = connected_emulators.map { |emu|
+        devices = list_connected_emulators.map { |emu|
             port = emu.split("-").last
             avd_name = get_emulator_name(port)
         }.compact

--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -71,11 +71,11 @@ module AndroidCIHelper
     end
 
     def self.get_emulator_name(port)
-        t = Net::Telnet::new("Host" => "localhost",
-                             "Port" => port,
-                             "Timeout" => 0.1)
         avd_name = nil
         begin
+            t = Net::Telnet::new("Host" => "localhost",
+                                 "Port" => port,
+                                 "Timeout" => 0.1)
             t.cmd("avd name") { |c| avd_name = c.split("\n").first }
         rescue
         end


### PR DESCRIPTION
This PR adds/changes the following 4 features:
1. add ability to `list_installed_emulators` to filter emulator by version and abi
2. add a function (`list_running_emulators`) the list the device names (AVD names) of the running device. This method is different from `list_connected_emulators` which returns the name of the connections (e.g., `emulator-5554`).
3. add ability to start emulator (`start_and_wait_for_ready`) without `-no-skin` parameter. This is required for UIAutomator to locate UI components.
4. increase the number of max attempts to check whether the emulator is started.

Thanks :dancers: 
