### PR TITLE
Fixes the issue where we sometimes cannot get correct AVD name

### DIFF
--- a/lib/android_ci_helper.rb
+++ b/lib/android_ci_helper.rb
@@ -1,4 +1,4 @@
-require "android_ci_helper/version"
+require_relative "android_ci_helper/version"
 require "net/telnet"
 
 module AndroidCIHelper
@@ -60,7 +60,15 @@ module AndroidCIHelper
             t = Net::Telnet::new("Host" => "localhost",
                                  "Port" => port,
                                  "Timeout" => 0.1)
-            t.cmd("avd name") { |c| avd_name = c.split("\n").first }
+            t.waitfor(/OK/n)
+            t.cmd("avd name") do |c|
+                avd_name = c.split("\n").first
+                # c is the output result for the commands. For the multiple-line
+                # result, it can come within a call or multiple calls
+                # since we only care about the first line of the result, if it is
+                # valid (not empty or nil), break.
+                break if avd_name
+            end
         rescue
         end
         avd_name


### PR DESCRIPTION
Fixes the issue where we sometimes cannot get correct AVD name

**_Test result:**_
Finished in 4.246561 seconds.
1 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

``` ruby
require_relative "../lib/android_ci_helper"
require "test/unit"
require "byebug"

class AndroidCIHelperTest < Test::Unit::TestCase
  # To test this, you must have an Android emulator launched already in place.
  def test_list_running_emulators
    0.upto(100) do |i|
      ret = AndroidCIHelper.list_running_emulators
      assert_not_equal("OK", ret.first)
    end
  end
end
```
